### PR TITLE
fix: improve terminal state handling and signal management

### DIFF
--- a/main.v
+++ b/main.v
@@ -1,16 +1,44 @@
 module main
 
+import os
 import clock
 import termctl
 import cli
 
 fn main() {
+	// parse flags and instantiate clock
 	cfg := cli.parse_args()
 	mut c := clock.new(cfg)
 
+	// initialize terminal state on the real tty
 	mut ts := termctl.TermState{}
+	// open /dev/tty for reliable control even if stdin is redirected
+	ts.open_tty('/dev/tty') or {
+		eprintln('failed to open /dev/tty: ${err}')
+		return
+	}
 	ts.enable_input_hiding()
 	defer { ts.disable_input_hiding() }
+
+	// register SIGINT handler
+	_ := os.signal_opt(.int, fn [mut ts] (_ os.Signal) {
+		ts.disable_input_hiding()
+		exit(0)
+	}) or {
+		eprintln('error: failed to register SIGINT handler: ${err}')
+		ts.disable_input_hiding()
+		exit(1)
+	}
+
+	// register SIGTERM handler
+	_ := os.signal_opt(.term, fn [mut ts] (_ os.Signal) {
+		ts.disable_input_hiding()
+		exit(0)
+	}) or {
+		eprintln('error: failed to register SIGTERM handler: ${err}')
+		ts.disable_input_hiding()
+		exit(1)
+	}
 
 	c.run()
 }

--- a/termctl/source.v
+++ b/termctl/source.v
@@ -1,5 +1,6 @@
 module termctl
 
+import os
 import term.termios
 
 pub struct TermState {
@@ -7,6 +8,11 @@ mut:
 	fd         int
 	original   termios.Termios
 	is_enabled bool
+}
+
+pub fn (mut ts TermState) open_tty(path string) ? {
+	ts.fd = os.open_file(path, 'r+')?.fd
+	return
 }
 
 pub fn (mut ts TermState) enable_input_hiding() {
@@ -20,8 +26,12 @@ pub fn (mut ts TermState) enable_input_hiding() {
 }
 
 pub fn (mut ts TermState) disable_input_hiding() {
+	if !ts.is_enabled {
+		return
+	}
 	termios.set_state(ts.fd, ts.original)
 	// ANSI escape sequence to display the terminal cursor
 	print('\x1b[?25h')
 	ts.is_enabled = false
+	_ = os.fd_close(ts.fd)
 }


### PR DESCRIPTION
Enhance the application's ability to properly manage terminal state and respond to interrupt signals, providing a more robust user experience.

- Add explicit TTY device opening via '/dev/tty' to ensure reliable terminal control even when stdin is redirected
- Implement proper signal handlers for SIGINT and SIGTERM to gracefully restore terminal state on exit
- Add defensive checks to avoid errors when disabling input hiding
- Ensure file descriptors are properly closed when terminal state is reset
- Add descriptive error messages for signal handler registration failures

These improvements help prevent terminal corruption and orphaned file descriptors when the application exits, whether normally or due to interruption signals.